### PR TITLE
chore(deps): update bun dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,8 +14,8 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.3.0",
-        "@types/node": "^25.9.1",
-        "@types/react": "^19.2.16",
+        "@types/node": "^25.9.2",
+        "@types/react": "^19.2.17",
         "@types/react-modal": "^3.16.3",
         "eslint-config-next": "^16.2.7",
         "postcss": "^8.5.15",

--- a/bun.lock
+++ b/bun.lock
@@ -249,9 +249,9 @@
 
     "@types/json5": ["@types/json5@0.0.29", "", {}, "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="],
 
-    "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
+    "@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
 
-    "@types/react": ["@types/react@19.2.16", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w=="],
+    "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 
     "@types/react-modal": ["@types/react-modal@3.16.3", "", { "dependencies": { "@types/react": "*" } }, "sha512-xXuGavyEGaFQDgBv4UVm8/ZsG+qxeQ7f77yNrW3n+1J6XAstUy5rYHeIHPh1KzsGc6IkCIdu6lQ2xWzu1jBTLg=="],
 

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.0",
-    "@types/node": "^25.9.1",
-    "@types/react": "^19.2.16",
+    "@types/node": "^25.9.2",
+    "@types/react": "^19.2.17",
     "@types/react-modal": "^3.16.3",
     "eslint-config-next": "^16.2.7",
     "postcss": "^8.5.15",


### PR DESCRIPTION
## Summary

Updates Bun-managed dependencies with `bun update`.

## Changed files

- bun.lock
- package.json

## bun update output

```text
bun update v1.3.14 (0d9b296a)
Resolving dependencies
Resolved, downloaded and extracted [32]
Saved lockfile

$ bun x only-allow bun
Resolving dependencies
Resolved, downloaded and extracted [4]
Saved lockfile

^ @types/node 25.9.1 -> 25.9.2
^ @types/react 19.2.16 -> 19.2.17

+ @tailwindcss/postcss@4.3.0
+ @types/react-modal@3.16.3
+ eslint-config-next@16.2.7
+ postcss@8.5.15
+ tailwindcss@4.3.0
+ typescript@6.0.3
+ @headlessui/react@2.2.10
+ @next/third-parties@16.2.7
+ @tailwindcss/forms@0.5.11
+ next@16.2.7
+ react@19.2.7
+ react-dom@19.2.7

391 packages installed [3.32s]
```

## Testing

- [ ] Not run; dependency update only
